### PR TITLE
fix pointer type comparison and unused variable warning

### DIFF
--- a/03_read_write/read_write.c
+++ b/03_read_write/read_write.c
@@ -28,7 +28,7 @@ static ssize_t driver_read(struct file *File, char *user_buffer, size_t count, l
 	int to_copy, not_copied, delta;
 
 	/* Get amount of data to copy */
-	to_copy = min(count, buffer_pointer);
+	to_copy = min_t(size_t, count, buffer_pointer);
 
 	/* Copy data to user */
 	not_copied = copy_to_user(user_buffer, buffer, to_copy);
@@ -86,7 +86,6 @@ static struct file_operations fops = {
  * @brief This function is called, when the module is loaded into the kernel
  */
 static int __init ModuleInit(void) {
-	int retval;
 	printk("Hello, Kernel!\n");
 
 	/* Allocate a device nr */


### PR DESCRIPTION
/opt/Linux_Driver_Tutorial/03_read_write/read_write.c: In function 'driver_read': /usr/src/linux-headers-6.1.0-rpi4-common-rpi/include/linux/minmax.h:20:35: warning: comparison of distinct pointer types lacks a cast
   20 |         (!!(sizeof((typeof(x) *)1 == (typeof(y) *)1)))
      |                                   ^~
/usr/src/linux-headers-6.1.0-rpi4-common-rpi/include/linux/minmax.h:26:18: note: in expansion of macro '__typecheck'
   26 |                 (__typecheck(x, y) && __no_side_effects(x, y))
      |                  ^~~~~~~~~~~
/usr/src/linux-headers-6.1.0-rpi4-common-rpi/include/linux/minmax.h:36:31: note: in expansion of macro '__safe_cmp'
   36 |         __builtin_choose_expr(__safe_cmp(x, y), \
      |                               ^~~~~~~~~~
/usr/src/linux-headers-6.1.0-rpi4-common-rpi/include/linux/minmax.h:45:25: note: in expansion of macro '__careful_cmp'
   45 | #define min(x, y)       __careful_cmp(x, y, <)
      |                         ^~~~~~~~~~~~~
/opt/Linux_Driver_Tutorial/03_read_write/read_write.c:31:19: note: in expansion of macro 'min'
   31 |         to_copy = min(count, buffer_pointer);
      |                   ^~~
/opt/Linux_Driver_Tutorial/03_read_write/read_write.c: In function 'ModuleInit':
/opt/Linux_Driver_Tutorial/03_read_write/read_write.c:89:13: warning: unused variable 'retval' [-Wunused-variable]
   89 |         int retval;
      |             ^~~~~~

* We need a cast for this comparison, so should use min_t() to fix build warning.
* retval was defined for return states but not used, so removed.